### PR TITLE
Multithreaded ChunkLoader

### DIFF
--- a/src/main/java/com/game/minecraft/Main.java
+++ b/src/main/java/com/game/minecraft/Main.java
@@ -17,6 +17,6 @@ public class Main {
 
     window.loop(camera, renderer);
 
-    window.cleanup();
+    window.cleanup(renderer);
   }
 }

--- a/src/main/java/com/game/minecraft/Window.java
+++ b/src/main/java/com/game/minecraft/Window.java
@@ -90,7 +90,8 @@ public class Window {
     }
   }
 
-  public void cleanup() {
+  public void cleanup(Renderer renderer) {
+    renderer.shutdown();
     glfwTerminate();
     glfwSetErrorCallback(null).free();
   }

--- a/src/main/java/com/game/minecraft/utils/FloatArray.java
+++ b/src/main/java/com/game/minecraft/utils/FloatArray.java
@@ -1,0 +1,42 @@
+package com.game.minecraft.utils;
+
+import java.util.Arrays;
+
+public class FloatArray {
+  private float[] data;
+  private int size;
+
+  public FloatArray(int initialCapacity) {
+    data = new float[initialCapacity];
+    size = 0;
+  }
+
+  public void add(float value) {
+    if (size == data.length) {
+      grow();
+    }
+    data[size++] = value;
+  }
+
+  private void grow() {
+    float[] newData = new float[data.length * 2];
+    System.arraycopy(data, 0, newData, 0, data.length);
+    data = newData;
+  }
+
+  public float get(int index) {
+    return data[index];
+  }
+
+  public float[] elements() {
+    return Arrays.copyOf(data, size);
+  }
+
+  public int size() {
+    return size;
+  }
+
+  public void clear() {
+    size = 0;
+  }
+}

--- a/src/main/java/com/game/minecraft/utils/LRU.java
+++ b/src/main/java/com/game/minecraft/utils/LRU.java
@@ -37,12 +37,6 @@ public class LRU {
       remove(node);
       insert(node);
       return node.val;
-    } else {
-      Blocks[][][] loaded = PersistStorage.loadFromFile(key);
-      if (loaded != null) {
-        put(key, loaded);
-        return loaded;
-      }
     }
     return null;
   }

--- a/src/main/java/com/game/minecraft/utils/PersistStorage.java
+++ b/src/main/java/com/game/minecraft/utils/PersistStorage.java
@@ -12,10 +12,14 @@ import java.util.UUID;
 
 public class PersistStorage {
 
-  public static final String INSTANCE_FILE_NAME = UUID.randomUUID().toString().replace("-", "");
+  private static String fileName = UUID.randomUUID().toString().replace("-", "");
+
+  public static void setWorldInstanceName(String name) {
+    fileName = name;
+  }
 
   public static void saveToFile(ChunkCoordinate coord, Blocks[][][] data) {
-    File dir = new File(INSTANCE_FILE_NAME);
+    File dir = new File(fileName);
     if (!dir.exists()) {
       dir.mkdir();
     }
@@ -30,7 +34,7 @@ public class PersistStorage {
   }
 
   public static Blocks[][][] loadFromFile(ChunkCoordinate coord) {
-    File file = new File(INSTANCE_FILE_NAME, coord.x() + "_" + coord.z() + ".dat");
+    File file = new File(fileName, coord.x() + "_" + coord.z() + ".dat");
     if (!file.exists()) {
       return null;
     }

--- a/src/main/java/com/game/minecraft/world/Block.java
+++ b/src/main/java/com/game/minecraft/world/Block.java
@@ -1,98 +1,100 @@
-package com.game.minecraft.world;
+// legacy: update to use FloatArray
 
-import static org.lwjgl.opengl.GL46C.*;
-import static org.lwjgl.system.MemoryStack.stackPush;
+// package com.game.minecraft.world;
 
-import java.nio.FloatBuffer;
-import java.util.ArrayList;
-import java.util.List;
-import org.joml.Matrix4f;
-import org.lwjgl.system.MemoryStack;
+// import static org.lwjgl.opengl.GL46C.*;
+// import static org.lwjgl.system.MemoryStack.stackPush;
 
-public class Block {
+// import java.nio.FloatBuffer;
+// import java.util.ArrayList;
+// import java.util.List;
+// import org.joml.Matrix4f;
+// import org.lwjgl.system.MemoryStack;
 
-  private final int vaoId;
-  private final int CUBE_VERTEX_COUNT = 36; // 6 faces, 2 triangles each, 3 vertices each
-  private final Matrix4f modelMatrix;
-  private final float xpos;
-  private final float ypos;
-  private final float zpos;
+// public class Block {
 
-  public Block(float xpos, float ypos, float zpos, Blocks block) {
-    this.vaoId = createBlockVAO(block);
-    this.xpos = xpos;
-    this.ypos = ypos;
-    this.zpos = zpos;
-    this.modelMatrix = new Matrix4f().translate(this.xpos, this.ypos, this.zpos);
-  }
+//   private final int vaoId;
+//   private final int CUBE_VERTEX_COUNT = 36; // 6 faces, 2 triangles each, 3 vertices each
+//   private final Matrix4f modelMatrix;
+//   private final float xpos;
+//   private final float ypos;
+//   private final float zpos;
 
-  public int getVaoId() {
-    return vaoId;
-  }
+//   public Block(float xpos, float ypos, float zpos, Blocks block) {
+//     this.vaoId = createBlockVAO(block);
+//     this.xpos = xpos;
+//     this.ypos = ypos;
+//     this.zpos = zpos;
+//     this.modelMatrix = new Matrix4f().translate(this.xpos, this.ypos, this.zpos);
+//   }
 
-  public int getCubeVertexCount() {
-    return CUBE_VERTEX_COUNT;
-  }
+//   public int getVaoId() {
+//     return vaoId;
+//   }
 
-  public Matrix4f getModelMatrix4f() {
-    return modelMatrix;
-  }
+//   public int getCubeVertexCount() {
+//     return CUBE_VERTEX_COUNT;
+//   }
 
-  public float getXpos() {
-    return xpos;
-  }
+//   public Matrix4f getModelMatrix4f() {
+//     return modelMatrix;
+//   }
 
-  public float getYpos() {
-    return ypos;
-  }
+//   public float getXpos() {
+//     return xpos;
+//   }
 
-  public float getZpos() {
-    return zpos;
-  }
+//   public float getYpos() {
+//     return ypos;
+//   }
 
-  private int createBlockVAO(Blocks block) {
-    List<Float> vertices = new ArrayList<>();
+//   public float getZpos() {
+//     return zpos;
+//   }
 
-    Vertex.addNormalTopFaceWithTexture(vertices, 0, 0, 0, block.getTopX(), block.getTopY());
-    Vertex.addNormalBottomFaceWithTexture(
-        vertices, 0, 0, 0, block.getBottomX(), block.getBottomY());
-    Vertex.addNormalFrontFaceWithTexture(vertices, 0, 0, 0, block.getSideX(), block.getSideY());
-    Vertex.addNormalBackFaceWithTexture(vertices, 0, 0, 0, block.getSideX(), block.getSideY());
-    Vertex.addNormalLeftFaceWithTexture(vertices, 0, 0, 0, block.getSideX(), block.getSideY());
-    Vertex.addNormalRightFaceWithTexture(vertices, 0, 0, 0, block.getSideX(), block.getSideY());
+//   private int createBlockVAO(Blocks block) {
+//     List<Float> vertices = new ArrayList<>();
 
-    float[] vertexData = new float[vertices.size()];
-    for (int i = 0; i < vertices.size(); i++) {
-      vertexData[i] = vertices.get(i);
-    }
+//     Vertex.addNormalTopFaceWithTexture(vertices, 0, 0, 0, block.getTopX(), block.getTopY());
+//     Vertex.addNormalBottomFaceWithTexture(
+//         vertices, 0, 0, 0, block.getBottomX(), block.getBottomY());
+//     Vertex.addNormalFrontFaceWithTexture(vertices, 0, 0, 0, block.getSideX(), block.getSideY());
+//     Vertex.addNormalBackFaceWithTexture(vertices, 0, 0, 0, block.getSideX(), block.getSideY());
+//     Vertex.addNormalLeftFaceWithTexture(vertices, 0, 0, 0, block.getSideX(), block.getSideY());
+//     Vertex.addNormalRightFaceWithTexture(vertices, 0, 0, 0, block.getSideX(), block.getSideY());
 
-    int vaoId = glGenVertexArrays();
-    glBindVertexArray(vaoId);
+//     float[] vertexData = new float[vertices.size()];
+//     for (int i = 0; i < vertices.size(); i++) {
+//       vertexData[i] = vertices.get(i);
+//     }
 
-    int vboId = glGenBuffers();
-    glBindBuffer(GL_ARRAY_BUFFER, vboId);
+//     int vaoId = glGenVertexArrays();
+//     glBindVertexArray(vaoId);
 
-    try (MemoryStack stack = stackPush()) {
-      FloatBuffer vertexBuffer = stack.mallocFloat(vertexData.length);
-      vertexBuffer.put(vertexData).flip(); // set position to 0
-      glBufferData(GL_ARRAY_BUFFER, vertexBuffer, GL_STATIC_DRAW);
-    }
+//     int vboId = glGenBuffers();
+//     glBindBuffer(GL_ARRAY_BUFFER, vboId);
 
-    glVertexAttribPointer(
-        0, // index, use 0 for xyz
-        3, // num of components: xyz
-        GL_FLOAT, // data type
-        false, // is normalized?
-        5 * Float.BYTES, // offset to next attributes (3 from index 0, 2 from index 1 below)
-        0L // starting position
-        );
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(1, 2, GL_FLOAT, false, 5 * Float.BYTES, 3L * Float.BYTES);
-    glEnableVertexAttribArray(1);
+//     try (MemoryStack stack = stackPush()) {
+//       FloatBuffer vertexBuffer = stack.mallocFloat(vertexData.length);
+//       vertexBuffer.put(vertexData).flip(); // set position to 0
+//       glBufferData(GL_ARRAY_BUFFER, vertexBuffer, GL_STATIC_DRAW);
+//     }
 
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindVertexArray(0);
+//     glVertexAttribPointer(
+//         0, // index, use 0 for xyz
+//         3, // num of components: xyz
+//         GL_FLOAT, // data type
+//         false, // is normalized?
+//         5 * Float.BYTES, // offset to next attributes (3 from index 0, 2 from index 1 below)
+//         0L // starting position
+//         );
+//     glEnableVertexAttribArray(0);
+//     glVertexAttribPointer(1, 2, GL_FLOAT, false, 5 * Float.BYTES, 3L * Float.BYTES);
+//     glEnableVertexAttribArray(1);
 
-    return vaoId;
-  }
-}
+//     glBindBuffer(GL_ARRAY_BUFFER, 0);
+//     glBindVertexArray(0);
+
+//     return vaoId;
+//   }
+// }

--- a/src/main/java/com/game/minecraft/world/ChunkLoader.java
+++ b/src/main/java/com/game/minecraft/world/ChunkLoader.java
@@ -1,0 +1,99 @@
+package com.game.minecraft.world;
+
+import com.game.minecraft.utils.PersistStorage;
+import java.util.Random;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class ChunkLoader implements Runnable {
+  static class ChunkLoadRequest {
+    final ChunkCoordinate coord;
+
+    ChunkLoadRequest(ChunkCoordinate coord) {
+      if (coord == null) throw new IllegalArgumentException("Null coordinate");
+      this.coord = coord;
+    }
+  }
+
+  static class ChunkLoadResult {
+    final ChunkCoordinate coord;
+    final Blocks[][][] blockData;
+
+    ChunkLoadResult(ChunkCoordinate coord, Blocks[][][] blockData) {
+      if (coord == null || blockData == null) throw new IllegalArgumentException();
+      this.coord = coord;
+      this.blockData = blockData;
+    }
+  }
+
+  private final BlockingQueue<ChunkLoadRequest> requestQueue = new LinkedBlockingQueue<>();
+  private final BlockingQueue<ChunkLoadResult> resultQueue = new LinkedBlockingQueue<>();
+
+  private volatile boolean running = true;
+
+  public void requestLoad(ChunkCoordinate coord) {
+    try {
+      requestQueue.put(new ChunkLoadRequest(coord));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  public ChunkLoadResult pollResult() {
+    return resultQueue.poll();
+  }
+
+  public void stopLoader() {
+    running = false;
+  }
+
+  @Override
+  public void run() {
+    while (running) {
+      try {
+        ChunkLoadRequest request = requestQueue.take();
+        if (request == null) {
+          continue;
+        }
+
+        Blocks[][][] data = PersistStorage.loadFromFile(request.coord);
+        if (data == null) {
+          data = generateFlatTerrainAt(request.coord);
+        }
+
+        resultQueue.put(new ChunkLoadResult(request.coord, data));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  public Blocks[][][] generateFlatTerrainAt(ChunkCoordinate coord) {
+    Blocks[][][] blocks = new Blocks[Chunk.CHUNK_X][Chunk.CHUNK_Y][Chunk.CHUNK_Z];
+    Random random = new Random();
+    int dirtHeight = Chunk.CHUNK_Y - (60 + random.nextInt(6));
+
+    for (int x = 0; x < Chunk.CHUNK_X; x++) {
+      for (int z = 0; z < Chunk.CHUNK_Z; z++) {
+
+        for (int y = 0; y < Chunk.CHUNK_Y; y++) {
+          if (y >= Chunk.CHUNK_Y - 5) {
+            blocks[x][y][z] = Blocks.BEDROCK;
+          } else if (y >= dirtHeight) {
+            blocks[x][y][z] = Blocks.DIRT;
+          } else if (y >= Chunk.CHUNK_Y - 60) {
+            blocks[x][y][z] = Blocks.STONE;
+          } else if (y == dirtHeight - 1) {
+            blocks[x][y][z] = Blocks.GRASS;
+          }
+        }
+      }
+    }
+    blocks[0][dirtHeight - 1][0] = Blocks.BEDROCK;
+    blocks[0][dirtHeight - 1][15] = Blocks.BEDROCK;
+    blocks[15][dirtHeight - 1][15] = Blocks.BEDROCK;
+    blocks[15][dirtHeight - 1][0] = Blocks.BEDROCK;
+
+    return blocks;
+  }
+}

--- a/src/main/java/com/game/minecraft/world/Direction.java
+++ b/src/main/java/com/game/minecraft/world/Direction.java
@@ -1,0 +1,8 @@
+package com.game.minecraft.world;
+
+public enum Direction {
+  FRONT,
+  BACK,
+  LEFT,
+  RIGHT
+}

--- a/src/main/java/com/game/minecraft/world/Vertex.java
+++ b/src/main/java/com/game/minecraft/world/Vertex.java
@@ -1,6 +1,6 @@
 package com.game.minecraft.world;
 
-import java.util.List;
+import com.game.minecraft.utils.FloatArray;
 
 public final class Vertex {
   public static final float ATLAS = 256.0f;
@@ -14,7 +14,7 @@ public final class Vertex {
   private Vertex() {}
 
   public static void addNormalTopFaceWithTexture(
-      List<Float> vertices, float x, float y, float z, float u, float v) {
+      FloatArray vertices, float x, float y, float z, float u, float v) {
     float uTopStart = u / ATLAS;
     float uTopEnd = (u + NORMAL_TILE) / ATLAS;
     float vTopStart = v / ATLAS;
@@ -45,7 +45,7 @@ public final class Vertex {
   }
 
   public static void addNormalBottomFaceWithTexture(
-      List<Float> vertices, float x, float y, float z, float u, float v) {
+      FloatArray vertices, float x, float y, float z, float u, float v) {
     float uBottomStart = u / ATLAS;
     float uBottomEnd = (u + NORMAL_TILE) / ATLAS;
     float vBottomStart = v / ATLAS;
@@ -76,7 +76,7 @@ public final class Vertex {
   }
 
   public static void addNormalFrontFaceWithTexture(
-      List<Float> vertices, float x, float y, float z, float u, float v) {
+      FloatArray vertices, float x, float y, float z, float u, float v) {
     float uSideStart = u / ATLAS;
     float uSideEnd = (u + NORMAL_TILE) / ATLAS;
     float vSideStart = v / ATLAS;
@@ -107,7 +107,7 @@ public final class Vertex {
   }
 
   public static void addNormalBackFaceWithTexture(
-      List<Float> vertices, float x, float y, float z, float u, float v) {
+      FloatArray vertices, float x, float y, float z, float u, float v) {
     float uSideStart = u / ATLAS;
     float uSideEnd = (u + NORMAL_TILE) / ATLAS;
     float vSideStart = v / ATLAS;
@@ -138,7 +138,7 @@ public final class Vertex {
   }
 
   public static void addNormalLeftFaceWithTexture(
-      List<Float> vertices, float x, float y, float z, float u, float v) {
+      FloatArray vertices, float x, float y, float z, float u, float v) {
     float uSideStart = u / ATLAS;
     float uSideEnd = (u + NORMAL_TILE) / ATLAS;
     float vSideStart = v / ATLAS;
@@ -169,7 +169,7 @@ public final class Vertex {
   }
 
   public static void addNormalRightFaceWithTexture(
-      List<Float> vertices, float x, float y, float z, float u, float v) {
+      FloatArray vertices, float x, float y, float z, float u, float v) {
     float uSideStart = u / ATLAS;
     float uSideEnd = (u + NORMAL_TILE) / ATLAS;
     float vSideStart = v / ATLAS;
@@ -205,7 +205,7 @@ public final class Vertex {
    * for UV texture coordinates).
    */
   private static void addFace(
-      List<Float> vertices,
+      FloatArray vertices,
       float x0,
       float y0,
       float z0,


### PR DESCRIPTION

- implement ChunkLoader:
  - dedicated thread to load (read) disk operations
  - moving all read from disk to ChunkLoader
- Render optimization:
  - only rebuild mesh if dirty
  - only build 2 chunks per frame
  - precalculate projection * view
  - bindtexture early and once
  - clean GPU and vertices before building
  - reduces object allocations by 4x (primitives vs. Float objects) by implementing FloatArray